### PR TITLE
Use interface for node values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## Unreleased
+
+Basic skiplist functionality
+
+- Skiplist interface for search, insert, delete
+- Iterator to iterate over nodes
+- A DupeList which allows for duplicate keys to be inserted with different values
+- Nodes use values of `interface{}` for generic usage

--- a/README.md
+++ b/README.md
@@ -78,23 +78,23 @@ Run tests with coverage
 Benchmarked with on a 2.3 GHz Intel Core i7.
 
 ```
+# Benchmarked on 2017-09-16
 goos: darwin
 goarch: amd64
 pkg: github.com/mtchavez/skiplist
-BenchmarkInsert_1000-8              2000            850617 ns/op
-BenchmarkInsert_10000-8              200           9111489 ns/op
-BenchmarkInsert_100000-8              10         112362795 ns/op
-BenchmarkInsert_1000000-8              1        2612950317 ns/op
-BenchmarkParallelInsert-8        1000000              2935 ns/op
-BenchmarkDelete_1000-8              5000            216831 ns/op
-BenchmarkDelete_10000-8              500           3288757 ns/op
-BenchmarkDelete_100000-8              30          44254999 ns/op
-BenchmarkDelete_1000000-8              3         432647827 ns/op
-BenchmarkParallelDelete-8        2000000               715 ns/op
+BenchmarkInsert_1000-8              2000            805488 ns/op
+BenchmarkInsert_10000-8              200           8370616 ns/op
+BenchmarkInsert_100000-8              20          98251825 ns/op
+BenchmarkInsert_1000000-8              1        1122310227 ns/op
+BenchmarkParallelInsert-8        1000000              1349 ns/op
+BenchmarkDelete_1000-8              5000            221056 ns/op
+BenchmarkDelete_10000-8              500           3577634 ns/op
+BenchmarkDelete_100000-8              30          61547826 ns/op
+BenchmarkDelete_1000000-8              2         611290978 ns/op
+BenchmarkParallelDelete-8        2000000               802 ns/op
 ```
 
 ## TODO
 
-* Update to use `interface{}` for key/value
-  * With a compare interface
+* Implement a compare interface
 * Concurrent skiplist implementation

--- a/dupe_list.go
+++ b/dupe_list.go
@@ -1,7 +1,7 @@
 package skiplist
 
 import (
-	"bytes"
+	"reflect"
 	"sync"
 )
 
@@ -73,7 +73,7 @@ func (l *DupeList) SearchKeyVal(key int, val []byte) *Node {
 	x = x.forward[0]
 	if x != nil {
 		for x != nil && x.key == key {
-			if bytes.Equal(x.val, val) {
+			if reflect.DeepEqual(x.val, val) {
 				return x
 			}
 			if x.forward != nil {
@@ -87,7 +87,7 @@ func (l *DupeList) SearchKeyVal(key int, val []byte) *Node {
 }
 
 // Insert a node into the list given a key and a byte array value
-func (l *DupeList) Insert(key int, val []byte) *Node {
+func (l *DupeList) Insert(key int, val interface{}) *Node {
 	update := make([]*Node, l.MaxLevel)
 	x := l.header
 	l.Lock()

--- a/dupe_list_test.go
+++ b/dupe_list_test.go
@@ -2,6 +2,7 @@ package skiplist
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 )
 
@@ -46,7 +47,7 @@ func TestDupeListSearchFound(t *testing.T) {
 	if found == nil {
 		t.Errorf("Should have found a node for 35")
 	}
-	if !bytes.Equal(found.val, []byte("My value")) {
+	if !bytes.Equal(reflect.ValueOf(found.val).Bytes(), []byte("My value")) {
 		t.Errorf("Value should have been 'My value'")
 	}
 }
@@ -59,7 +60,7 @@ func TestDupeListSearchDupeKeys(t *testing.T) {
 	if found == nil {
 		t.Errorf("Should have found a node for 35")
 	}
-	if !bytes.Equal(found.val, []byte("35 35")) {
+	if !bytes.Equal(reflect.ValueOf(found.val).Bytes(), []byte("35 35")) {
 		t.Errorf("Value should have been '35 35' but got %+v", found.val)
 	}
 }
@@ -73,7 +74,7 @@ func TestDupeListSearchKeyVal(t *testing.T) {
 		t.Errorf("Should not have found a node with mismatched value but got %+v", found)
 	}
 	found = l.SearchKeyVal(35, []byte("My value"))
-	if !bytes.Equal(found.val, []byte("My value")) {
+	if !bytes.Equal(reflect.ValueOf(found.val).Bytes(), []byte("My value")) {
 		t.Errorf("Value should have been 'My value' but got %+v", found.val)
 	}
 }

--- a/iterator.go
+++ b/iterator.go
@@ -6,7 +6,7 @@ package skiplist
 type Iterator interface {
 	Next() (ok bool)
 	Prev() (ok bool)
-	Val() []byte
+	Val() interface{}
 	Key() int
 }
 
@@ -34,7 +34,7 @@ func (i *iterable) Prev() bool {
 	return true
 }
 
-func (i *iterable) Val() []byte {
+func (i *iterable) Val() interface{} {
 	if i.curr == nil {
 		return nil
 	}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2,6 +2,7 @@ package skiplist
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 )
 
@@ -15,7 +16,7 @@ func TestNext(t *testing.T) {
 	i.Next()
 	l.Insert(3, []byte("Node three"))
 	i.Next()
-	if !bytes.Equal(i.Val(), []byte("Node three")) {
+	if !bytes.Equal(reflect.ValueOf(i.Val()).Bytes(), []byte("Node three")) {
 		t.Errorf("Didn't iterate to next node")
 	}
 	if i.Key() != 3 {

--- a/list_example_test.go
+++ b/list_example_test.go
@@ -1,6 +1,9 @@
 package skiplist
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
 func ExampleNewList() {
 	l := NewList()
@@ -39,7 +42,7 @@ func ExampleList_Search() {
 	found := l.Search(4)
 
 	fmt.Printf("Searched for 45 and got %+v\n", notFound)
-	fmt.Printf("Searched for 4 and got '%+v'\n", string(found.Value()))
+	fmt.Printf("Searched for 4 and got '%+v'\n", string(reflect.ValueOf(found.Value()).Bytes()))
 	// Output:
 	// Searched for 45 and got <nil>
 	// Searched for 4 and got 'example 4'
@@ -53,7 +56,7 @@ func ExampleList_Delete() {
 	l.Insert(4, []byte("example 4"))
 
 	found := l.Search(4)
-	fmt.Printf("Searched for 4 and got '%+v'\n", string(found.Value()))
+	fmt.Printf("Searched for 4 and got '%+v'\n", string(reflect.ValueOf(found.Value()).Bytes()))
 
 	// Delete node
 	fmt.Printf("Deleted key 4? %+v\n", l.Delete(4))

--- a/node.go
+++ b/node.go
@@ -7,13 +7,13 @@ type Node struct {
 	forward  []*Node
 	backward *Node
 	key      int
-	val      []byte
+	val      interface{}
 }
 
 // NewNode takes a level used for the forward slice
 // referencing linked nodes as well as the key and
 // value of the node
-func NewNode(level, key int, val []byte) *Node {
+func NewNode(level, key int, val interface{}) *Node {
 	return &Node{
 		forward: make([]*Node, level),
 		key:     key,
@@ -22,7 +22,7 @@ func NewNode(level, key int, val []byte) *Node {
 }
 
 // Value returns val of node
-func (n *Node) Value() []byte {
+func (n *Node) Value() interface{} {
 	return n.val
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -2,6 +2,7 @@ package skiplist
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 )
 
@@ -13,7 +14,7 @@ func TestNewNode(t *testing.T) {
 	if n.key != 2 {
 		t.Errorf("Key should be set to 2")
 	}
-	if !bytes.Equal(n.val, []byte("Node two")) {
+	if !bytes.Equal(reflect.ValueOf(n.val).Bytes(), []byte("Node two")) {
 		t.Errorf("Val should be set to 'Node two'")
 	}
 }

--- a/skiplist.go
+++ b/skiplist.go
@@ -17,7 +17,7 @@ const (
 type SkipList interface {
 	Search(key int) *Node
 	Delete(key int) bool
-	Insert(key int, val []byte) *Node
+	Insert(key int, val interface{}) *Node
 	Iterator() Iterator
 }
 
@@ -93,7 +93,7 @@ func (l *List) Search(key int) *Node {
 // Insert a new node into the skip list providing a
 // integer key and a byte array value. Will return
 // the inserted Node
-func (l *List) Insert(key int, val []byte) *Node {
+func (l *List) Insert(key int, val interface{}) *Node {
 	update := make([]*Node, l.MaxLevel)
 	x := l.header
 	var alreadyChecked *Node

--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -2,6 +2,7 @@ package skiplist
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 )
 
@@ -46,7 +47,7 @@ func TestSearchFound(t *testing.T) {
 	if found == nil {
 		t.Errorf("Should have found a node for 35")
 	}
-	if !bytes.Equal(found.val, []byte("My value")) {
+	if !bytes.Equal(reflect.ValueOf(found.val).Bytes(), []byte("My value")) {
 		t.Errorf("Value should have been 'My value'")
 	}
 }


### PR DESCRIPTION
## What

Rather than restrict nodes to `[]byte` values allow `interface{}` for more
flexibility.

## Changes

- Update skiplist interface to use interface{} on Insert
- Update Node and Iterator to use interface{}
- Update tests and examples to use reflect for byte values
- Update benchmarks
- Remove TODO that was implemented
- Add a CHANGELOG with unreleased version notes